### PR TITLE
Limit file size for uploads to 6MB

### DIFF
--- a/gifsync/static/css/create.css
+++ b/gifsync/static/css/create.css
@@ -27,6 +27,10 @@ input[type=file]:focus, .custom-file-input:focus ~ .custom-file-label {
     box-shadow: none;
 }
 
+.custom-file {
+    margin-top: 6px;
+}
+
 /* Change cursor to pointer on File Select */
 .custom-file,
 .custom-file-label,

--- a/gifsync/templates/create.html
+++ b/gifsync/templates/create.html
@@ -11,6 +11,7 @@
     <form class="form-center" method="POST" action="" enctype="multipart/form-data" novalidate>
         {{ form.hidden_tag() }}
         <div class="form-group row">
+            <small class="justify-content-center">Maximum file size: 6MB</small>
             <div class="custom-file">
                 {{ form.gif_file(class="custom-file-input", accept=".gif") }}
                 {{ form.gif_file.label(class="custom-file-label text-truncate") }}


### PR DESCRIPTION
The new image processing, while better in the sense that gifs don't come out all artifact-like, comes with the drawback of significantly increasing frame creation times especially for higher-quality gifs. In an attempt to limit the amount of 30-second timeouts, I've capped the upload size to 6MB. Some gifs, if they are of high color-density or quality, will still take longer than the 30-second window to reload, and thus a prompt to refresh the page after 30 seconds is displayed.

Also fixed login loop when going to /logout route while not signed on.