### PR TITLE
added support for error codes

### DIFF
--- a/gifsync/__init__.py
+++ b/gifsync/__init__.py
@@ -51,11 +51,16 @@ else:
     # Manually set OAUTHLIB_INSECURE_TRANSPORT so we don't have to include it in environment variables
     os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
 
+@app.errorhandler(400)
+@app.errorhandler(401)
+@app.errorhandler(404)
+def error_page(error):
+    return render_template('error.html', error = str(error).split(':')), 400
+
 
 @login_manager.user_loader
 def load_user(user_id):
     return SpotifyUser.query.filter(SpotifyUser.id == str(user_id)).first()
-
 
 @login_manager.unauthorized_handler
 def unauthorized():

--- a/gifsync/__init__.py
+++ b/gifsync/__init__.py
@@ -51,16 +51,18 @@ else:
     # Manually set OAUTHLIB_INSECURE_TRANSPORT so we don't have to include it in environment variables
     os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
 
+
 @app.errorhandler(400)
 @app.errorhandler(401)
 @app.errorhandler(404)
 def error_page(error):
-    return render_template('error.html', error = str(error).split(':')), 400
+    return render_template('error.html', error=str(error).split(':')), error.code
 
 
 @login_manager.user_loader
 def load_user(user_id):
     return SpotifyUser.query.filter(SpotifyUser.id == str(user_id)).first()
+
 
 @login_manager.unauthorized_handler
 def unauthorized():

--- a/gifsync/static/css/error.css
+++ b/gifsync/static/css/error.css
@@ -1,22 +1,3 @@
-/* Link Base Styling */
-a {
-    font-weight: bold;
-    color: #1db954;
-}
-
-/* Link Hover Styling */
-a:hover {
-    color: #20cb5c;
-}
-
-/* Logo Styling */
-.logo {
-    /* Margin is added to the bottom to space out page text from the logo */
-    width: 256px;
-    height: 256px;
-    margin-bottom: 32px;
-}
-
 /* Title Text Styling */
 .title {
     color: #1db954;
@@ -33,12 +14,4 @@ a:hover {
     font-size: 24px;
     /* Margin is added to the left to make headers stand apart from body text, and margin bottom to space out
        header from the body text */
-    margin-left: 30px;
-    margin-bottom: 18px;
-}
-
-.page-footer {
-    position: absolute;
-    width: 100%;
-    bottom: 0;
 }

--- a/gifsync/static/css/error.css
+++ b/gifsync/static/css/error.css
@@ -1,0 +1,44 @@
+/* Link Base Styling */
+a {
+    font-weight: bold;
+    color: #1db954;
+}
+
+/* Link Hover Styling */
+a:hover {
+    color: #20cb5c;
+}
+
+/* Logo Styling */
+.logo {
+    /* Margin is added to the bottom to space out page text from the logo */
+    width: 256px;
+    height: 256px;
+    margin-bottom: 32px;
+}
+
+/* Title Text Styling */
+.title {
+    color: #1db954;
+    font-weight: bold;
+    font-size: 46px;
+    /* Margin is added to the bottom to space out title from the rest of the page's text for emphasis */
+    margin-bottom: 64px;
+}
+
+/* Header Text Styling */
+.header {
+    font-weight: bold;
+    font-style: italic;
+    font-size: 24px;
+    /* Margin is added to the left to make headers stand apart from body text, and margin bottom to space out
+       header from the body text */
+    margin-left: 30px;
+    margin-bottom: 18px;
+}
+
+.page-footer {
+    position: absolute;
+    width: 100%;
+    bottom: 0;
+}

--- a/gifsync/static/css/home.css
+++ b/gifsync/static/css/home.css
@@ -1,22 +1,3 @@
-/* Link Base Styling */
-a {
-    font-weight: bold;
-    color: #1db954;
-}
-
-/* Link Hover Styling */
-a:hover {
-    color: #20cb5c;
-}
-
-/* Logo Styling */
-.logo {
-    /* Margin is added to the bottom to space out page text from the logo */
-    width: 256px;
-    height: 256px;
-    margin-bottom: 32px;
-}
-
 /* Title Text Styling */
 .title {
     color: #1db954;

--- a/gifsync/static/css/skeleton.css
+++ b/gifsync/static/css/skeleton.css
@@ -1,3 +1,8 @@
+html {
+    position: relative;
+    min-height: 100%;
+}
+
 /* Generic styling for all pages */
 body {
     font-family: "Ubuntu", serif;
@@ -5,12 +10,21 @@ body {
     color: #b2b2b2;
     /* Top padding is necessary to move body of page below the navbar, since the navbar is fixed to the top */
     padding-top: 107px;
+    padding-bottom: 53px; /* Fixed footer height */
 }
 
 /* Footer style */
 .footer-copyright {
     font-size: 14px;
     background-color: #282828;
+}
+
+.page-footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 53px; /* Fixed footer height */
+  background-color: #b2b2b2;
 }
 
 /* Navbar Base Styling */
@@ -43,6 +57,25 @@ body {
 /* Navbar Spacing between List elements, ex: buttons */
 .navbar-custom .navbar-nav > li {
     margin: 10px 15px;
+}
+
+/* Link Base Styling */
+a {
+    font-weight: bold;
+    color: #1db954;
+}
+
+/* Link Hover Styling */
+a:hover {
+    color: #20cb5c;
+}
+
+/* Logo Styling */
+.logo {
+    /* Margin is added to the bottom to space out page text from the logo */
+    width: 256px;
+    height: 256px;
+    margin-bottom: 32px;
 }
 
 /* Green Button Base Styling */

--- a/gifsync/templates/error.html
+++ b/gifsync/templates/error.html
@@ -1,0 +1,20 @@
+{% extends "skeleton.html" %}
+
+{% block styles %}
+    <!-- Link the css file specifically for this page -->
+    <link rel="stylesheet" type="text/css"
+          href="{{ url_for('static', filename='css/error.css') }}">
+{% endblock styles %}
+
+{% block content %}
+
+<div class = 'body'>
+    <img class="mx-auto d-block logo"
+         src="{{ url_for('static', filename='img/logo.png') }}">
+
+    <h1 class="text-center title">{{ error[0] }}</h1>
+
+    <p class = 'text-center'>{{ error[1] }}</p>
+</div>
+
+{% endblock content %}


### PR DESCRIPTION
Added support for error codes 400, 401, 404.

Since there were no special cases for these error codes, I added them all to the same method and gave that method multiple errorhandlers. 

For more advanced error handling, these can be split into multiple functions. The error was split into a list on the : to allow the title of the page to be the simple error code e.g. 404 Not Found. and then underneath in smaller text the actual error message (which is always the default one).

Furthermore, I added a custom CSS file to ensure that the footer was stickied to the bottom of the page and I increased the title text size to make the error code stand out.