### PR TITLE
Change default hat kid speed

### DIFF
--- a/gifsync/__init__.py
+++ b/gifsync/__init__.py
@@ -172,7 +172,7 @@ def callback():
             hat_kid_image = Image(image.read())
         if not Image.query.filter(Image.id == hat_kid_image.id).first():
             db.session.add(hat_kid_image)
-        hat_kid_gif = Gif(user.id, hat_kid_image.id, 'Hat Kid', 4)
+        hat_kid_gif = Gif(user.id, hat_kid_image.id, 'Hat Kid', 2)
         db.session.add(hat_kid_gif)
         db.session.commit()
     login_user(user)


### PR DESCRIPTION
Modify default gif's beats per loop from 4 to 2, because I think it looks better and it better illustrates the syncing capabilities of gifsync.